### PR TITLE
include a serial and adc object to the template

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,11 @@ fn main() -> ! {
 
     {% case board -%}
       {%- when "Arduino Leonardo", "Arduino Mega 2560", "Arduino Nano", "Arduino Uno", "Nano168" -%}
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600); // not strictly necessary, but still useful
+    let _ = ufmt::uwriteln!(&mut serial, "hello from Arduino");
+
+    let mut adc = arduino_hal::Adc::new(dp.ADC, Default::default()); // only needed if you want to sample analog pins
+
     let mut led = pins.d13.into_output();
       {%- when "SparkFun ProMicro" -%}
     let mut led = pins.led_rx.into_output();


### PR DESCRIPTION
While the focus of this template is mostly providing the AVR scaffolding, I feel that the main.rs could benefit from a couple of more examples of how to create objects to access important peripherals.  By referencing them here, a new coder will more quickly learn what to search for in the more detailed examples.