### PR TITLE
Update toolchain, get rid of the std-features hack

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -36,7 +36,6 @@
 
 [unstable]
 build-std = ["core"]
-build-std-features = ["compiler-builtins-mangled-names"]
 {%- comment %}
 # vim: ft=toml.jinja2
 {% endcomment %}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-05-10"
+channel = "nightly-2022-06-13"
 components = ["rust-src"]
 profile = "minimal"


### PR DESCRIPTION
The `compiler-builtins-mangled-names` thingie¹ is no longer needed,
since `compiler_builtins` has been improved to avoid pulling the
problematic functions:

- https://github.com/rust-lang/compiler-builtins/pull/462
- https://github.com/rust-lang/compiler-builtins/pull/466
- https://github.com/rust-lang/rust/pull/97435

¹ https://github.com/rust-lang/rust/issues/82242