### PR TITLE
Add Arduino Nano New Bootloader

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,6 +10,8 @@
     target = "avr-specs/avr-atmega2560.json"
   {%- when "Arduino Nano" -%}
     target = "avr-specs/avr-atmega328p.json"
+  {%- when "Arduino Nano New Bootloader" -%}
+    target = "avr-specs/avr-atmega328p.json"
   {%- when "Arduino Uno" -%}
     target = "avr-specs/avr-atmega328p.json"
   {%- when "SparkFun ProMicro" -%}
@@ -30,6 +32,8 @@
     runner = "ravedude mega2560 -cb 57600"
   {%- when "Arduino Nano" -%}
     runner = "ravedude nano -cb 57600"
+  {%- when "Arduino Nano New Bootloader" -%}
+    runner = "ravedude nano-new -cb 57600"
   {%- when "Arduino Uno" -%}
     runner = "ravedude uno -cb 57600"
   {%- when "SparkFun ProMicro" -%}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ rev = "1aacefb335517f85d0de858231e11055d9768cdf"
     features = ["arduino-mega2560"]
   {%- when "Arduino Nano" -%}
     features = ["arduino-nano"]
+  {%- when "Arduino Nano New Bootloader" -%}
+    features = ["arduino-nano"]
   {%- when "Arduino Uno" -%}
     features = ["arduino-uno"]
   {%- when "SparkFun ProMicro" -%}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ time:
  - Arduino Leonardo
  - Arduino Mega 2560
  - Arduino Nano
+ - Arduino Nano New Bootloader (Manufactured after January 2018)
  - Arduino Uno
  - SparkFun ProMicro
  - Adafruit Trinket

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -7,6 +7,7 @@ choices = [
   "Arduino Leonardo",
   "Arduino Mega 2560",
   "Arduino Nano",
+  "Arduino Nano New Bootloader",
   "Arduino Uno",
   "SparkFun ProMicro",
   "Nano168",

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() -> ! {
     {% case board -%}
       {%- when "Adafruit Trinket" -%}
     let mut led = pins.d1.into_output();
-      {%- when "Arduino Leonardo", "Arduino Mega 2560", "Arduino Nano", "Arduino Uno", "Nano168", "Adafruit Trinket Pro" -%}
+      {%- when "Arduino Leonardo", "Arduino Mega 2560", "Arduino Nano", "Arduino Nano New Bootloader", "Arduino Uno", "Nano168", "Adafruit Trinket Pro" -%}
     let mut led = pins.d13.into_output();
       {%- when "SparkFun ProMicro" -%}
     let mut led = pins.led_rx.into_output();


### PR DESCRIPTION
Since `ravedude v.0.1.5` can handle Arduino Nano with the new bootloader, I added a bit of code so nano-new can be used with this template. I've tried it out on my Nano.

Just let me know if you want me to change anything.