### PR TITLE
Add support for Digispark + Micronucleus

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,7 @@
 [build]
 {% case board -%}
+  {%- when "Digispark + Micronucleus" -%}
+    target = "avr-specs/avr-attiny85.json"
   {%- when "Adafruit Trinket" -%}
     target = "avr-specs/avr-attiny85.json"
   {%- when "Adafruit Trinket Pro" -%}
@@ -22,6 +24,8 @@
 
 [target.'cfg(target_arch = "avr")']
 {% case board -%}
+  {%- when "Digispark + Micronucleus" -%}
+    runner = "micronucleus-runner"
   {%- when "Adafruit Trinket" -%}
     runner = "ravedude trinket"
   {%- when "Adafruit Trinket Pro" -%}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ embedded-hal = "0.2.3"
 git = "https://github.com/rahix/avr-hal"
 rev = "3b8f39fa2ec5e3359c7bedc33d982e75e8cc3700"
 {% case board -%}
-  {%- when "Adafruit Trinket", "Digispark + Micronucleus" -%}
+  {%- when "Digispark + Micronucleus" -%}
+    features = ["digispark"]
+  {%- when "Adafruit Trinket" -%}
     features = ["trinket"]
   {%- when "Adafruit Trinket Pro" -%}
     features = ["trinket-pro"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ embedded-hal = "0.2.3"
 git = "https://github.com/rahix/avr-hal"
 rev = "3b8f39fa2ec5e3359c7bedc33d982e75e8cc3700"
 {% case board -%}
-  {%- when "Adafruit Trinket" -%}
+  {%- when "Adafruit Trinket", "Digispark + Micronucleus" -%}
     features = ["trinket"]
   {%- when "Adafruit Trinket Pro" -%}
     features = ["trinket-pro"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ time:
  - SparkFun ProMicro
  - Adafruit Trinket
  - Adafruit Trinket Pro
+ - Digispark + Micronucleus
 
 ## Usage
 If you don't have them already, install [`cargo-generate`] and [`ravedude`]:
@@ -20,6 +21,13 @@ If you don't have them already, install [`cargo-generate`] and [`ravedude`]:
 cargo install cargo-generate
 cargo install ravedude
 ```
+
+Alternatively if you are uploading to a board with the Micronucleus 'virtual usb' bootloader use [`micronucleus-runner`]:
+```bash
+cargo install cargo-generate
+cargo install micronucleus-runner
+```
+
 
 Then instanciate this template:
 
@@ -37,8 +45,8 @@ cargo run
 and see a blinky flashed to your board!
 
 [`cargo-generate`]: https://github.com/cargo-generate/cargo-generate
-[`ravedude`]: https://github.com/Rahix/avr-hal/tree/next/ravedude
-
+[`ravedude`]: https://github.com/Rahix/avr-hal/tree/main/ravedude
+[`micronucleus-runner`]:https://github.com/Rahix/avr-hal/tree/main/micronucleus-runner
 ## License
 Licensed under either of
 

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -11,5 +11,6 @@ choices = [
   "Arduino Uno",
   "SparkFun ProMicro",
   "Nano168",
+  "Digispark + Micronucleus"
 ]
 default = "Arduino Uno"

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> ! {
      */
 
     {% case board -%}
-      {%- when "Adafruit Trinket" -%}
+      {%- when "Adafruit Trinket", "Digispark + Micronucleus" -%}
     let mut led = pins.d1.into_output();
       {%- when "Arduino Leonardo", "Arduino Mega 2560", "Arduino Nano", "Arduino Nano New Bootloader", "Arduino Uno", "Nano168", "Adafruit Trinket Pro" -%}
     let mut led = pins.d13.into_output();


### PR DESCRIPTION
These changes add support for the Digispark board with the Micronucleus ATtiny 'virtual usb' boot loader

Requires PR https://github.com/Rahix/avr-hal/pull/364 to be merged,

then BEFORE PUBLISHING update line 21 in Cargo.toml:

    19 [dependencies.arduino-hal]
    20 git = "https://github.com/rahix/avr-hal"
    21 rev = "3b8f39fa2ec5e3359c7bedc33d982e75e8cc3700"