### PR TITLE
Optionally generate boilerplate for UART console

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -15,6 +15,11 @@ choices = [
 ]
 default = "Arduino Uno"
 
+[placeholders.use_uart_console]
+type = "bool"
+prompt = "Include boilerplate for UART console?"
+default = false
+
 [template]
 ignore=["README.md"]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,9 @@ use panic_halt as _;
 fn main() -> ! {
     let dp = arduino_hal::Peripherals::take().unwrap();
     let pins = arduino_hal::pins!(dp);
+    {%- if use_uart_console %}
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+    {%- endif %}
 
     /*
      * For examples (and inspiration), head to
@@ -35,6 +38,11 @@ fn main() -> ! {
       {%- when "SparkFun ProMicro" -%}
     let mut led = pins.led_rx.into_output();
     {%- endcase %}
+
+    {% if use_uart_console -%}
+    ufmt::uwriteln!(&mut serial, "Hello from {{ board }}!").void_unwrap();
+
+    {% endif -%}
 
     loop {
         led.toggle();


### PR DESCRIPTION
I'm very unsure where we should go this route, but I want to at least raise the possibility.

This PR adds a new prompt during project generation which asks the user whether they want additional boilerplate for a UART console in their project.  This can of course be extended for other devices like I2C, SPI, panic handlers, etc.

One one hand, it would make starting a new project a bit faster.  On the other, it means additional effort to keep the template up-to-date and has the chance of people just enabling everything "because maybe I'll need it" and then leaving the code sitting in their project unused.  Not sure if we want to enable that...

In any case, I think this PR needs to wait until https://github.com/cargo-generate/cargo-generate/issues/885 is resolved.