### PR TITLE
feat: add sparkfun-promini-v5

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,6 +18,8 @@
     target = "avr-specs/avr-atmega328p.json"
   {%- when "SparkFun ProMicro" -%}
     target = "avr-specs/avr-atmega32u4.json"
+  {%- when "SparkFun ProMini 5v" -%}
+    target = "avr-specs/avr-atmega328p.json"
   {%- when "Nano168" -%}
     target = "avr-specs/avr-atmega168.json"
 {%- endcase %}
@@ -42,6 +44,8 @@
     runner = "ravedude uno -cb 57600"
   {%- when "SparkFun ProMicro" -%}
     runner = "ravedude promicro"
+  {%- when "SparkFun ProMini 5v" -%}
+    runner = "ravedude promini-5v"
   {%- when "Nano168" -%}
     runner = "ravedude nano168 -cb 57600"
 {%- endcase %}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ rev = "190f2c3cb8d29e10f71119352b912369dc5a1fb7"
     features = ["arduino-uno"]
   {%- when "SparkFun ProMicro" -%}
     features = ["sparkfun-promicro"]
+  {%- when "SparkFun ProMini 5v" -%}
+    features = ["sparkfun-promicro-5v"]
   {%- when "Nano168" -%}
     features = ["nano168"]
 {%- endcase %}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rev = "190f2c3cb8d29e10f71119352b912369dc5a1fb7"
   {%- when "SparkFun ProMicro" -%}
     features = ["sparkfun-promicro"]
   {%- when "SparkFun ProMini 5v" -%}
-    features = ["sparkfun-promicro-5v"]
+    features = ["sparkfun-promini-5v"]
   {%- when "Nano168" -%}
     features = ["nano168"]
 {%- endcase %}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ time:
  - Arduino Nano New Bootloader (Manufactured after January 2018)
  - Arduino Uno
  - SparkFun ProMicro
+ - SpartFun ProMini 5v
  - Adafruit Trinket
  - Adafruit Trinket Pro
 

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -11,6 +11,7 @@ choices = [
   "Arduino Nano New Bootloader",
   "Arduino Uno",
   "SparkFun ProMicro",
+  "SparkFun ProMini 5v",
   "Nano168",
 ]
 default = "Arduino Uno"

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,13 +29,11 @@ fn main() -> ! {
         "Arduino Nano New Bootloader",
         "Arduino Uno",
         "Nano168",
-        "Adafruit Trinket Pro"
+        "Adafruit Trinket Pro",
+        "SparkFun ProMini 5v"
       -%}
     let mut led = pins.d13.into_output();
-      {%- when
-        "SparkFun ProMicro",
-        "SparFun ProMini 5v"
-      -%}
+      {%- when "SparkFun ProMicro" -%}
     let mut led = pins.led_rx.into_output();
     {%- endcase %}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,10 @@ fn main() -> ! {
         "Adafruit Trinket Pro"
       -%}
     let mut led = pins.d13.into_output();
-      {%- when "SparkFun ProMicro" -%}
+      {%- when
+        "SparkFun ProMicro",
+        "SparFun ProMini 5v"
+      -%}
     let mut led = pins.led_rx.into_output();
     {%- endcase %}
 


### PR DESCRIPTION
Following [this pr](https://github.com/Rahix/avr-hal/pull/435) I found there is no support for this in the cargo templating.

I have tried adding it here, but I am not totally sure its done correctly. 

(closes #24)