### PR TITLE
feat: add sparkfun-promini-3v

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,6 +18,8 @@
     target = "avr-specs/avr-atmega328p.json"
   {%- when "SparkFun ProMicro" -%}
     target = "avr-specs/avr-atmega32u4.json"
+  {%- when "SparkFun ProMini 3v" -%}
+    target = "avr-specs/avr-atmega328p.json"
   {%- when "SparkFun ProMini 5v" -%}
     target = "avr-specs/avr-atmega328p.json"
   {%- when "Nano168" -%}
@@ -44,6 +46,8 @@
     runner = "ravedude uno -cb 57600"
   {%- when "SparkFun ProMicro" -%}
     runner = "ravedude promicro"
+  {%- when "SparkFun ProMini 3v" -%}
+    runner = "ravedude promini-3v"
   {%- when "SparkFun ProMini 5v" -%}
     runner = "ravedude promini-5v"
   {%- when "Nano168" -%}

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,7 +18,7 @@
     target = "avr-specs/avr-atmega328p.json"
   {%- when "SparkFun ProMicro" -%}
     target = "avr-specs/avr-atmega32u4.json"
-  {%- when "SparkFun ProMini 3v" -%}
+  {%- when "SparkFun ProMini 3v3" -%}
     target = "avr-specs/avr-atmega328p.json"
   {%- when "SparkFun ProMini 5v" -%}
     target = "avr-specs/avr-atmega328p.json"
@@ -46,8 +46,8 @@
     runner = "ravedude uno -cb 57600"
   {%- when "SparkFun ProMicro" -%}
     runner = "ravedude promicro"
-  {%- when "SparkFun ProMini 3v" -%}
-    runner = "ravedude promini-3v"
+  {%- when "SparkFun ProMini 3v3" -%}
+    runner = "ravedude promini-3v3"
   {%- when "SparkFun ProMini 5v" -%}
     runner = "ravedude promini-5v"
   {%- when "Nano168" -%}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ rev = "21342dcace7184f01fdc4e9703b01197bd4b4b4f"
     features = ["arduino-uno"]
   {%- when "SparkFun ProMicro" -%}
     features = ["sparkfun-promicro"]
+  {%- when "SparkFun ProMini 3v" -%}
+    features = ["sparkfun-promini-3v"]
   {%- when "SparkFun ProMini 5v" -%}
     features = ["sparkfun-promini-5v"]
   {%- when "Nano168" -%}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ rev = "21342dcace7184f01fdc4e9703b01197bd4b4b4f"
     features = ["arduino-uno"]
   {%- when "SparkFun ProMicro" -%}
     features = ["sparkfun-promicro"]
-  {%- when "SparkFun ProMini 3v" -%}
-    features = ["sparkfun-promini-3v"]
+  {%- when "SparkFun ProMini 3v3" -%}
+    features = ["sparkfun-promini-3v3"]
   {%- when "SparkFun ProMini 5v" -%}
     features = ["sparkfun-promini-5v"]
   {%- when "Nano168" -%}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ time:
  - Arduino Nano New Bootloader (Manufactured after January 2018)
  - Arduino Uno
  - SparkFun ProMicro
- - SpartFun ProMini 3v
+ - SpartFun ProMini 3.3V
  - SpartFun ProMini 5v
  - Adafruit Trinket
  - Adafruit Trinket Pro

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ time:
  - Arduino Nano New Bootloader (Manufactured after January 2018)
  - Arduino Uno
  - SparkFun ProMicro
+ - SpartFun ProMini 3v
  - SpartFun ProMini 5v
  - Adafruit Trinket
  - Adafruit Trinket Pro

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -11,6 +11,7 @@ choices = [
   "Arduino Nano New Bootloader",
   "Arduino Uno",
   "SparkFun ProMicro",
+  "SparkFun ProMini 3v",
   "SparkFun ProMini 5v",
   "Nano168",
 ]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -11,7 +11,7 @@ choices = [
   "Arduino Nano New Bootloader",
   "Arduino Uno",
   "SparkFun ProMicro",
-  "SparkFun ProMini 3v",
+  "SparkFun ProMini 3v3",
   "SparkFun ProMini 5v",
   "Nano168",
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
         "Arduino Uno",
         "Nano168",
         "Adafruit Trinket Pro",
-        "SparkFun ProMini 3v",
+        "SparkFun ProMini 3v3",
         "SparkFun ProMini 5v"
       -%}
     let mut led = pins.d13.into_output();

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ fn main() -> ! {
         "Arduino Uno",
         "Nano168",
         "Adafruit Trinket Pro",
+        "SparkFun ProMini 3v",
         "SparkFun ProMini 5v"
       -%}
     let mut led = pins.d13.into_output();


### PR DESCRIPTION
This is in reference to [this PR](https://github.com/Rahix/avr-hal/pull/445) on avr-hal which isn't accepted, so this is just a draft PR for now.

This PR adds promini-3v to the cargo generate template. 