### PR TITLE
Use Ravedude.toml instead of CLI ravedude configuration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -28,32 +28,7 @@ target = "avr-none"
 {%- endcase %}
 
 [target.'cfg(target_arch = "avr")']
-{% case board -%}
-  {%- when "Adafruit Trinket" -%}
-    runner = "ravedude trinket"
-  {%- when "Adafruit Trinket Pro" -%}
-    runner = "ravedude trinket-pro"
-  {%- when "Arduino Leonardo" -%}
-    runner = "ravedude leonardo"
-  {%- when "Arduino Mega 2560" -%}
-    runner = "ravedude mega2560 -cb 57600"
-  {%- when "Arduino Mega 1280" -%}
-    runner = "ravedude mega1280 -cb 57600"
-  {%- when "Arduino Nano" -%}
-    runner = "ravedude nano -cb 57600"
-  {%- when "Arduino Nano New Bootloader" -%}
-    runner = "ravedude nano-new -cb 57600"
-  {%- when "Arduino Uno" -%}
-    runner = "ravedude uno -cb 57600"
-  {%- when "SparkFun ProMicro" -%}
-    runner = "ravedude promicro"
-  {%- when "SparkFun ProMini 3v3" -%}
-    runner = "ravedude promini-3v3"
-  {%- when "SparkFun ProMini 5v" -%}
-    runner = "ravedude promini-5v"
-  {%- when "Nano168" -%}
-    runner = "ravedude nano168 -cb 57600"
-{%- endcase %}
+runner = "ravedude"
 
 [unstable]
 build-std = ["core"]

--- a/Ravedude.toml
+++ b/Ravedude.toml
@@ -1,0 +1,43 @@
+[general]
+{% case board -%}
+  {%- when "Adafruit Trinket" -%}
+    board = "trinket"
+  {%- when "Adafruit Trinket Pro" -%}
+    board = "trinket-pro"
+  {%- when "Arduino Leonardo" -%}
+    board = "leonardo"
+  {%- when "Arduino Mega 2560" -%}
+    board = "mega2560"
+  {%- when "Arduino Mega 1280" -%}
+    board = "mega1280"
+  {%- when "Arduino Nano" -%}
+    board = "nano"
+  {%- when "Arduino Nano New Bootloader" -%}
+    board = "nano-new"
+  {%- when "Arduino Uno" -%}
+    board = "uno"
+  {%- when "SparkFun ProMicro" -%}
+    board = "promicro"
+  {%- when "SparkFun ProMini 3v3" -%}
+    board = "promini-3v3"
+  {%- when "SparkFun ProMini 5v" -%}
+    board = "promini-5v"
+  {%- when "Nano168" -%}
+    board = "nano168"
+{%- endcase %}
+{% case board -%}
+  {%- when
+    "Arduino Mega 2560",
+    "Arduino Mega 1280",
+    "Arduino Nano",
+    "Arduino Nano New Bootloader",
+    "Arduino Uno",
+    "Nano168"
+  -%}
+# After flashing, open the serial console at 57600 baud.
+open-console = true
+serial-baudrate = 57600
+{%- endcase %}
+{%- comment %}
+# vim: ft=toml.jinja2
+{% endcomment %}

--- a/Ravedude.toml
+++ b/Ravedude.toml
@@ -37,7 +37,20 @@
 # After flashing, open the serial console at 57600 baud.
 open-console = true
 serial-baudrate = 57600
+  {%- when
+    "Arduino Leonardo",
+    "Arduino ProMicro"
+  -%}
+# The {{ board }} does not have a UART console like other Arduino boards.
+# Instead, it can emulate a console device over USB, but this is not yet
+# supported in `avr-hal`.  To get console output from an {{ board }}, you
+# need to connect an external usb-serial converter to the TX/RX pins of your
+# board.
+open-console = false
 {%- endcase %}
+
+# For documentation about this file, check here:
+# https://github.com/Rahix/avr-hal/blob/main/ravedude/README.md#ravedudetoml-format
 {%- comment %}
 # vim: ft=toml.jinja2
 {% endcomment %}


### PR DESCRIPTION
In preparation for the new ravedude configuration introduced in <https://github.com/Rahix/avr-hal/pull/522>, update the template to generate a `Ravedude.toml`.