### PR TITLE
Add allow for panic_halt unused import

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+#[allow(unused_imports)]
 use panic_halt as _;
 
 #[arduino_hal::entry]


### PR DESCRIPTION
use panic_halt shows as a unused import, so there could be added an exception for it to look better
and for import organization to not delete it as it is still needed

![obraz](https://github.com/user-attachments/assets/f8db7222-e32d-4ebe-a1b5-707b22443e40)
